### PR TITLE
Ensure proper include path used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ ifeq ($(MIX_ENV),dev)
 endif
 
 LDFLAGS += `pkg-config --static --libs glfw3 glew`
+CFLAGS += `pkg-config --static --cflags glfw3 glew`
 
 
 ifneq ($(OS),Windows_NT)


### PR DESCRIPTION
@boydm This does not build properly under MacPorts as it does not find the headers in /opt/local/include. Note that I don't have a currently usable linux box to test, nor do I use Homebrew, so I'm not sure of the impact there (though it should work).