### PR TITLE
Add c99 to the CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 \MIX = mix
-CFLAGS = -O3
+CFLAGS = -O3 -std=c99
 
 ifndef MIX_ENV
 	MIX_ENV = dev


### PR DESCRIPTION
Not including this results in a failure to build with the following
error (gcc 4.8.4).

> ==> scenic_driver_glfw mkdir -p priv/prod
>
> cc -O3 -fPIC -o priv/prod/scenic_driver_glfw c_src/main.c c_src/comms.c
> c_src/nanovg/nanovg.c c_src/utils.c c_src/render_script.c c_src/tx.c
> `pkg-config --static --libs glfw3 glew` -lGL -lm -lrt
>
> c_src/render_script.c: In function ‘delete_all’:
>
> c_src/render_script.c:118:3: error: ‘for’ loop initial declarations are
> only allowed in C99 mode for (GLuint i = 0; i < p_data->num_scripts; i++
> ) { ^
>
> c_src/render_script.c:118:3: note: use option -std=c99 or -std=gnu99 to
> compile your code
>
> c_src/render_script.c: In function ‘arc’:
>
> c_src/render_script.c:576:5: error: ‘for’ loop initial declarations are
> only allowed in C99 mode
>
>      for (int i = 0; i <= segment_count; ++i) { ^
>
> c_src/render_script.c: In function ‘sector’:
>
> c_src/render_script.c:614:5: error: ‘for’ loop initial declarations are
> only allowed in C99 mode
>
>      for (int i = 0; i <= segment_count; ++i) { ^ make: ***
>      [priv/prod/scenic_driver_glfw] Error 1 could not compile dependency
>      :scenic_driver_glfw, "mix compile" failed. You can recompile this
>      dependency with "mix deps.compile scenic_driver_glfw", update it
>      with "mix deps.update scenic_driver_glfw" or clean it with "mix
>      deps.clean scenic_driver_glfw"