### PR TITLE
Fix/update clear color

### DIFF
--- a/lib/glfw/graph.ex
+++ b/lib/glfw/graph.ex
@@ -65,9 +65,11 @@ defmodule Scenic.Driver.Glfw.Graph do
   # --------------------------------------------------------
   def handle_cast(
         :update_clear_color,
-        %{port: port, root_ref: root_key, clear_color: old_clear_color} = state
+        %{port: port, root_ref: master_graph_key, clear_color: old_clear_color} = state
       ) do
-    with {:ok, graph} <- ViewPort.Tables.get_graph(root_key) do
+    with {:ok, master_graph} <- ViewPort.Tables.get_graph(master_graph_key),
+         {:ok, %{data: {Primitive.SceneRef, root_key}}} <- Map.fetch(master_graph, 1),
+         {:ok, graph} <- ViewPort.Tables.get_graph(root_key) do
       root_group = graph[0]
 
       clear_color =

--- a/test/glfw_test.exs
+++ b/test/glfw_test.exs
@@ -65,6 +65,14 @@ defmodule Scenic.Driver.GlfwTest do
     Process.sleep(1500)
     Glfw.Cache.load_texture(@parrot_hash, state.port)
 
+    # clear
+    Graph.build(clear_color: :green)
+    |> test_push_graph(graph_key)
+
+    {:noreply, state} = Glfw.handle_cast({:set_root, graph_key}, state)
+    state = %{state | pending_flush: false, dirty_graphs: []}
+    Process.sleep(40)
+
     # arc
     Graph.build()
     |> arc({100, 0, 1}, stroke: {2, :green}, translate: {300, 300})


### PR DESCRIPTION
This is a follow up from https://github.com/boydm/scenic/issues/99

Under the assumption that the master graph will **always** retain the form:

```elixir
master_graph = %{
      0 => %{data: {Primitive.Group, [1]}, transforms: [...]},
      1 => %{data: {Primitive.SceneRef, root_graph_key}}
    }
```
These changes adjust the handlers that trigger the update of `clear_color` so that they correctly point to the root graph (which contains the styles) instead of the master graph.

In an attempt to minimize confusion, the `:root_ref` state parameter was also renamed to `:master_ref`.

Relative performance impacts exist in the sense that operations such as `render_one_graph` and `update_clear_color` now require an additional cache read. (is there a shortcut to this that I might've overlooked?)