### PR TITLE
Correct link to documentation, remove default text

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you're using wayland, you'll probably need `glfw-wayland` instead of `glfw-x1
 
 ## General Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+As this is a hex package, it can be installed
 by adding `scenic_driver_glfw` to your list of dependencies in `mix.exs`:
 
 ```elixir
@@ -54,7 +54,7 @@ def deps do
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/scenic_driver_mac](https://hexdocs.pm/scenic_driver_mac).
+## Documentation
+
+Documentation can be found at [https://hexdocs.pm/scenic_driver_glfw](https://hexdocs.pm/scenic_driver_glfw).
 


### PR DESCRIPTION
Hi,

Awesome work, I look forward using it :D

As I read the README I found some outdated info(link to docs and some default hex packaging suggestions), hence this PR.

Thanks again for your hard work!