### PR TITLE
use the updated loaders

### DIFF
--- a/lib/glfw/font.ex
+++ b/lib/glfw/font.ex
@@ -29,7 +29,7 @@ defmodule Scenic.Driver.Glfw.Font do
           :code.priv_dir(:scenic_driver_glfw)
           |> Path.join(@font_folder)
 
-        with {:ok, ^hash} <- Cache.Static.Font.load(hash, font_folder),
+        with {:ok, ^hash} <- Cache.Static.Font.load(font_folder, hash),
              {:ok, font} <- Cache.Static.Font.fetch(hash) do
           do_load_font(font, hash, port)
         end


### PR DESCRIPTION
Put the order of params on the new cache loaders back the way it way. Wasn't worth the trouble.