### PR TITLE
fix path problems which lead to new projects not running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 \MIX = mix
 CFLAGS = -O3 -std=c99
 
+PREFIX=$(MIX_COMPILE_PATH)/../priv
+
 ifndef MIX_ENV
 	MIX_ENV = dev
 endif
@@ -31,7 +33,7 @@ endif
 
 .PHONY: all clean
 
-all: priv/$(MIX_ENV)/scenic_driver_glfw
+all: $(PREFIX)/$(MIX_ENV)/scenic_driver_glfw
 # fonts
 
 SRCS = c_src/main.c c_src/comms.c c_src/nanovg/nanovg.c \
@@ -39,8 +41,8 @@ SRCS = c_src/main.c c_src/comms.c c_src/nanovg/nanovg.c \
 	# c_src/nanovg/nanovg.c
 	# c_src/render.c c_src/text.c c_src/texture.c
 
-priv/$(MIX_ENV)/scenic_driver_glfw: $(SRCS)
-	mkdir -p priv/$(MIX_ENV)
+$(PREFIX)/$(MIX_ENV)/scenic_driver_glfw: $(SRCS)
+	mkdir -p $(PREFIX)/$(MIX_ENV)
 	$(CC) $(CFLAGS) -o $@ $(SRCS) $(LDFLAGS)
 
 # fonts: priv/

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,6 @@ $(PREFIX)/$(MIX_ENV)/scenic_driver_glfw: $(SRCS)
 # 	ln -fs ../fonts priv/
 
 clean:
-	$(RM) -r priv/dev
-	$(RM) -r priv/test
-	$(RM) -r priv/prod
+	$(RM) -r $(PREFIX)/$(MIX_ENV)
+#	$(RM) -r $(PREFIX)/test
+#	$(RM) -r $(PREFIX)/prod


### PR DESCRIPTION
This is a potential fix for #25 and a similar bug [in scenic](https://github.com/boydm/scenic_new/issues/36).  I have tested it with a fresh project generated from mix scenic.new.example as well as mix scenic.new and it works with both MIX_ENV=prod or MIX_ENV=dev, first time and further times.