### PR TITLE
Added libglew 2.1 for ubuntu 20.04 version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,24 @@ brew install glfw3 glew pkg-config
 
 Once these components have been installed, you should be able to build the `scenic_driver_glfw` driver.
 
-### Installing on Ubuntu
+### Installing on Ubuntu 18.04
 
 The easiest way to install on Ubuntu is to use apt-get. Just run the following:
 
 ```bash
 apt-get update
 apt-get install pkgconf libglfw3 libglfw3-dev libglew2.0 libglew-dev
+```
+
+Once these components have been installed, you should be able to build the `scenic_driver_glfw` driver.
+
+### Installing on Ubuntu 20.04
+
+The easiest way to install on Ubuntu is to use apt-get. Just run the following:
+
+```bash
+apt-get update
+apt-get install pkgconf libglfw3 libglfw3-dev libglew2.1 libglew-dev
 ```
 
 Once these components have been installed, you should be able to build the `scenic_driver_glfw` driver.


### PR DESCRIPTION
When using ubuntu 20 you will get the following error when trying to install.
```
sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew2.0 libglew-dev
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package libglew2.0
E: Couldn't find any package by glob 'libglew2.0'
E: Couldn't find any package by regex 'libglew2.0'
```
This it because Ubuntu 20 uses libglew 2.1.

Added section to readme basically.



